### PR TITLE
Support USB-MIDI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,6 @@ add_executable(${CMAKE_PROJECT_NAME}
   src/button.c
   src/tap_tempo.c
   src/display.c
-  src/ble_midi.c
-  src/usb_midi.c
 )
 pico_btstack_make_gatt_header(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_LIST_DIR}/midi_service.gatt)
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_LIST_DIR}/include)
@@ -23,6 +21,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
 )
 
 add_library(ble_midi INTERFACE)
+target_sources(ble_midi INTERFACE src/ble_midi.c)
 target_link_libraries(ble_midi INTERFACE
   pico_btstack_ble
   pico_btstack_cyw43
@@ -30,7 +29,8 @@ target_link_libraries(ble_midi INTERFACE
 )
 
 add_library(usb_midi INTERFACE)
-target_link_libraries(ble_midi INTERFACE
+target_sources(usb_midi INTERFACE src/usb_midi.c)
+target_link_libraries(usb_midi INTERFACE
   tinyusb_device
   tinyusb_board
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,19 +8,32 @@ pico_sdk_init()
 
 add_executable(${CMAKE_PROJECT_NAME}
   src/main.c
-  src/ble_midi.c
   src/button.c
   src/tap_tempo.c
   src/display.c
+  src/ble_midi.c
+  src/usb_midi.c
 )
 pico_btstack_make_gatt_header(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_LIST_DIR}/midi_service.gatt)
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_LIST_DIR}/include)
 target_link_libraries(${CMAKE_PROJECT_NAME}
   pico_stdlib
+  ble_midi
+  usb_midi
+)
+
+add_library(ble_midi INTERFACE)
+target_link_libraries(ble_midi INTERFACE
   pico_btstack_ble
   pico_btstack_cyw43
   pico_cyw43_arch_none
 )
+
+add_library(usb_midi INTERFACE)
+target_link_libraries(ble_midi INTERFACE
+  tinyusb_device
+  tinyusb_board
+)
+
 pico_enable_stdio_usb(${CMAKE_PROJECT_NAME} 1)
 pico_add_extra_outputs(${CMAKE_PROJECT_NAME})
-

--- a/include/tusb_config.h
+++ b/include/tusb_config.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#define BOARD_TUD_RHPORT      0
+
+#define BOARD_TUD_MAX_SPEED   OPT_MODE_DEFAULT_SPEED
+
+#define CFG_TUD_ENABLED       1
+
+#define CFG_TUD_MAX_SPEED     BOARD_TUD_MAX_SPEED
+
+#ifndef CFG_TUSB_MEM_SECTION
+#define CFG_TUSB_MEM_SECTION
+#endif
+
+#ifndef CFG_TUSB_MEM_ALIGN
+#define CFG_TUSB_MEM_ALIGN        __attribute__ ((aligned(4)))
+#endif
+
+#ifndef CFG_TUD_ENDPOINT0_SIZE
+#define CFG_TUD_ENDPOINT0_SIZE    64
+#endif
+
+#define CFG_TUD_CDC               1
+#define CFG_TUD_MIDI              1
+
+// MIDI FIFO size of TX and RX
+#define CFG_TUD_MIDI_RX_BUFSIZE   (TUD_OPT_HIGH_SPEED ? 512 : 64)
+#define CFG_TUD_MIDI_TX_BUFSIZE   (TUD_OPT_HIGH_SPEED ? 512 : 64)
+
+#define CFG_TUD_CDC_RX_BUFSIZE  (64)
+#define CFG_TUD_CDC_TX_BUFSIZE  (64)
+#define CFG_TUD_CDC_EP_BUFSIZE  (64)

--- a/include/usb_midi.h
+++ b/include/usb_midi.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2025, Hiroyuki OYAMA
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#pragma once
+
+void usb_midi_init(void);
+
+bool usb_midi_is_connected(void);
+
+void usb_midi_send_note(uint8_t channel, uint8_t note, uint8_t velocity);
+
+void usb_midi_task(void);

--- a/src/usb_midi.c
+++ b/src/usb_midi.c
@@ -1,0 +1,145 @@
+#include <stdio.h>
+
+#include "bsp/board_api.h"
+#include "pico/bootrom.h"
+#include "tusb.h"
+
+#define _PID_MAP(itf, n) ((CFG_TUD_##itf) << (n))
+#define USB_PID                                                                            \
+    (0x4000 | _PID_MAP(CDC, 0) | _PID_MAP(MSC, 1) | _PID_MAP(HID, 2) | _PID_MAP(MIDI, 3) | \
+     _PID_MAP(VENDOR, 4))
+
+tusb_desc_device_t const desc_device = {.bLength = sizeof(tusb_desc_device_t),
+                                        .bDescriptorType = TUSB_DESC_DEVICE,
+                                        .bcdUSB = 0x0200,
+                                        .bDeviceClass = 0x00,
+                                        .bDeviceSubClass = 0x00,
+                                        .bDeviceProtocol = 0x00,
+                                        .bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
+
+                                        .idVendor = 0xCafe,
+                                        .idProduct = USB_PID,
+                                        .bcdDevice = 0x0100,
+
+                                        .iManufacturer = 0x01,
+                                        .iProduct = 0x02,
+                                        .iSerialNumber = 0x03,
+                                        .bNumConfigurations = 0x01};
+
+uint8_t const *tud_descriptor_device_cb(void) { return (uint8_t const *)&desc_device; }
+
+enum { ITF_NUM_MIDI = 0, ITF_NUM_MIDI_STREAMING, ITF_NUM_CDC, ITF_NUM_CDC_DATA, ITF_NUM_TOTAL };
+
+#define CONFIG_TOTAL_LEN (TUD_CONFIG_DESC_LEN + TUD_MIDI_DESC_LEN + TUD_CDC_DESC_LEN)
+
+#define EPNUM_MIDI_OUT 0x01
+#define EPNUM_MIDI_IN 0x81
+
+#define EPNUM_CDC_NOTIF 0x82  // notification endpoint for CDC
+#define EPNUM_CDC_OUT 0x03    // out endpoint for CDC
+#define EPNUM_CDC_IN 0x83     // in endpoint for CDC
+
+uint8_t const desc_configuration[] = {
+    TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, 0x00, 100),
+    TUD_MIDI_DESCRIPTOR(ITF_NUM_MIDI, 0, EPNUM_MIDI_OUT, (0x80 | EPNUM_MIDI_IN), 64),
+    TUD_CDC_DESCRIPTOR(ITF_NUM_CDC, 4, EPNUM_CDC_NOTIF, 8, EPNUM_CDC_OUT, EPNUM_CDC_IN, 64)};
+
+uint8_t const *tud_descriptor_configuration_cb(uint8_t index) {
+    (void)index;
+    return desc_configuration;
+}
+
+enum {
+    STRID_LANGID = 0,
+    STRID_MANUFACTURER,
+    STRID_PRODUCT,
+    STRID_SERIAL,
+};
+
+char const *string_desc_arr[] = {
+    (const char[]){0x09, 0x04},  // 0: is supported language is English (0x0409)
+    "TinyUSB",                   // 1: Manufacturer
+    "Pico MIDI Looper",          // 2: Product
+    NULL, "Pico stdio"};
+
+static uint16_t _desc_str[32 + 1];
+
+uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
+    (void)langid;
+    size_t chr_count;
+    switch (index) {
+        case STRID_LANGID:
+            memcpy(&_desc_str[1], string_desc_arr[0], 2);
+            chr_count = 1;
+            break;
+
+        case STRID_SERIAL:
+            chr_count = board_usb_get_serial(_desc_str + 1, 32);
+            break;
+
+        default:
+            // Note: the 0xEE index string is a Microsoft OS 1.0 Descriptors.
+            // https://docs.microsoft.com/en-us/windows-hardware/drivers/usbcon/microsoft-defined-usb-descriptors
+            if (!(index < sizeof(string_desc_arr) / sizeof(string_desc_arr[0]))) {
+                return NULL;
+            }
+
+            const char *str = string_desc_arr[index];
+
+            // Cap at max char
+            chr_count = strlen(str);
+            const size_t max_count =
+                sizeof(_desc_str) / sizeof(_desc_str[0]) - 1;  // -1 for string type
+            if (chr_count > max_count) {
+                chr_count = max_count;
+            }
+
+            // Convert ASCII string into UTF-16
+            for (size_t i = 0; i < chr_count; i++) {
+                _desc_str[1 + i] = str[i];
+            }
+            break;
+    }
+
+    // first byte is length (including header), second byte is string type
+    _desc_str[0] = (uint16_t)((TUSB_DESC_STRING << 8) | (2 * chr_count + 2));
+
+    return _desc_str;
+}
+
+void tud_cdc_line_coding_cb(uint8_t itf, cdc_line_coding_t const *p_line_coding) {
+    if (p_line_coding->bit_rate == 1200) {
+        reset_usb_boot(0, 0);
+    }
+}
+
+void usb_midi_init(void) {
+    board_init();
+
+    tud_init(BOARD_TUD_RHPORT);
+    if (board_init_after_tusb) {
+        board_init_after_tusb();
+    }
+}
+
+bool usb_midi_is_connected(void) { return tud_mounted(); }
+
+void usb_midi_send_note(uint8_t channel, uint8_t note, uint8_t velocity) {
+    uint8_t const cable_num = 0;
+    // Send Note On for current position at full velocity (127) on channel 1.
+    uint8_t note_on[] = {0x90 | channel, note, velocity};
+    tud_midi_stream_write(cable_num, note_on, sizeof(note_on));
+
+    // Send Note Off for previous note.
+    uint8_t note_off[] = {0x80 | channel, note, 0};
+    tud_midi_stream_write(cable_num, note_off, sizeof(note_off));
+}
+
+void usb_midi_task(void) {
+    tud_task();
+
+    while (tud_midi_available()) {
+        uint8_t packet[4];
+        tud_midi_packet_read(packet);
+    }
+}


### PR DESCRIPTION
Add `src/usb_midi.c` module to support USB MIDI output.

It can be written in the same line as `ble_midi.c`, but it is not smart because `tud_task()` needs to be executed from the main loop side.
Also, the amount of description will simply increase, so careful consideration is needed in deciding whether to merge or not. However, the nature of the sounding system is very convenient: just plug in the USB cable and it will start ringing.

- [x] Confirmation of operation with Standard Pico
- [ ] code cleanup
- [ ] add comment
- [ ] update documents